### PR TITLE
#655 メッセージ画面の表示崩れ(Windows IE11) 

### DIFF
--- a/message-template.html
+++ b/message-template.html
@@ -39,8 +39,8 @@
     flex-direction: row-reverse;
   }
   .message-container.sent .message {
-    display: flex;
-    flex-direction: column;
+    /*display: flex;*/
+    /*flex-direction: column;*/
   }
   .message-container .avatar {
     margin: 16px;

--- a/message-template.html
+++ b/message-template.html
@@ -40,7 +40,7 @@
   }
   .message-container.sent .message {
     /*display: flex;*/
-    /*flex-direction: column;*/
+    flex-direction: column;
   }
   .message-container .avatar {
     margin: 16px;

--- a/messages-template.html
+++ b/messages-template.html
@@ -17,7 +17,7 @@
                 <span class="mdl-chip__text"><span class="mdl-typography--font-bold">活動場所</span>：<?php echo $message['location']; ?>　　</span>
                 <span class="date mdl-typography--caption mdl-color-text--grey-500"><?php echo $message['create_date']; ?></span>
               </div>
-              <p class="mdl-list__item-text-body mdl-typography--body-color-contrast">
+              <p class="message mdl-list__item-text-body mdl-typography--body-color-contrast">
                 <?php echo $message['content']; ?>
               </p>
             </span>
@@ -81,5 +81,8 @@
 }
 .mdl-list__item .mdl-typography--subhead .mdl-chip__text{
   margin-right: auto;
+}
+p.message {
+  width: 100%;
 }
 </style>


### PR DESCRIPTION
### IE11 での表示崩れを修正
* message-template.html
  - `display: flex;` 粗削除
* messages-template.html
  - メッセージ部分に幅を指定