### PR TITLE
#640 空のメッセージが送信できる

### DIFF
--- a/js/message.js
+++ b/js/message.js
@@ -21,7 +21,7 @@ $(function(){
     if(length > 0) {
       disabled = false;
     }
-    $(".qa-part-form-message button").prop("disabled", disabled);
+    $("#send-message").prop("disabled", disabled);
     if(disabled) {
       $("#content-error").show();
     } else {

--- a/js/message.js
+++ b/js/message.js
@@ -15,7 +15,7 @@ $(function(){
     content = content.replace(/<p><br><\/p>/g, '');
     content = content.replace(/<p class=""><br><\/p>/g, '');    
     content = content.replace(/<p class="">(&nbsp;\s?)*<\/p>/g, '');
-    console.log(content);
+    // console.log(content);
     var length = content.length;
     var disabled = true;
     if(length > 0) {

--- a/js/message.js
+++ b/js/message.js
@@ -1,0 +1,33 @@
+
+$(function(){
+  // turn_off_submit_by_enter();
+  update_confirm_status();
+
+  var content_elem = document.getElementById('content');
+  var content_editor = new MediumEditor('.editable');
+  editor.subscribe('editableInput', function (event, editable) {
+      update_confirm_status();
+  });
+
+
+  function update_confirm_status(){
+    var content = get_content('content');
+    content = content.replace(/<p><br><\/p>/g, '');
+    content = content.replace(/<p class=""><br><\/p>/g, '');    
+    content = content.replace(/<p class="">(&nbsp;\s?)*<\/p>/g, '');
+    console.log(content);
+    var length = content.length;
+    var disabled = true;
+    if(length > 0) {
+      disabled = false;
+    }
+    $(".qa-part-form-message button").prop("disabled", disabled);
+    if(disabled) {
+      $("#content-error").show();
+    } else {
+      $("#content-error").hide();
+    }
+  }
+  
+  
+});

--- a/qa-custom-messages-lang-default.php
+++ b/qa-custom-messages-lang-default.php
@@ -3,6 +3,7 @@
   return array(
     // default japanese
     'messages_page_title' => 'メッセージボックス',
+    'messege_input_error' => '何か入力してください',
   );
 
 /*

--- a/qa-custom-messages-layer.php
+++ b/qa-custom-messages-layer.php
@@ -28,11 +28,12 @@ class qa_html_theme_layer extends qa_html_theme_base {
   public function message_list_and_form($list)
   {
     if (qa_opt('site_theme') === CML_TARGET_THEME_NAME && $this->template === 'message') {
-      $input_error_msg = qa_lang('custom_messages/messege_input_error');
-      $this->output('<div id="content-error" class="mdl-card__supporting-text">');
-      $this->output('<span class="mdl-color-text--red">', $input_error_msg, '</span>');
-      $this->output('</div>');
-
+      if (strpos(qa_get_state(), 'message-sent') === false) {
+          $input_error_msg = qa_lang('custom_messages/messege_input_error');
+          $this->output('<div id="content-error" class="mdl-card__supporting-text">');
+          $this->output('<span class="mdl-color-text--red">', $input_error_msg, '</span>');
+          $this->output('</div>');
+      }
       $this->part_title($list);
 
       $this->error(@$list['error']);
@@ -88,7 +89,9 @@ class qa_html_theme_layer extends qa_html_theme_base {
   public function body_footer()
   {
       if (qa_opt('site_theme') === CML_TARGET_THEME_NAME && $this->template === 'message') {
+        if (strpos(qa_get_state(), 'message-sent') === false) {
           $this->output('<script src="'. CML_RELATIVE_PATH . 'js/message.js' . '"></script>');
+        }
       }
   }
 }

--- a/qa-custom-messages-layer.php
+++ b/qa-custom-messages-layer.php
@@ -28,7 +28,11 @@ class qa_html_theme_layer extends qa_html_theme_base {
   public function message_list_and_form($list)
   {
     if (qa_opt('site_theme') === CML_TARGET_THEME_NAME && $this->template === 'message') {
-      
+      $input_error_msg = qa_lang('custom_messages/messege_input_error');
+      $this->output('<div id="content-error" class="mdl-card__supporting-text">');
+      $this->output('<span class="mdl-color-text--red">', $input_error_msg, '</span>');
+      $this->output('</div>');
+
       $this->part_title($list);
 
       $this->error(@$list['error']);
@@ -79,5 +83,12 @@ class qa_html_theme_layer extends qa_html_theme_base {
       }
     }
     qa_html_theme_base::nav($navtype, $level);
+  }
+  
+  public function body_footer()
+  {
+      if (qa_opt('site_theme') === CML_TARGET_THEME_NAME && $this->template === 'message') {
+          $this->output('<script src="'. CML_RELATIVE_PATH . 'js/message.js' . '"></script>');
+      }
   }
 }

--- a/qa-custom-messages-layer.php
+++ b/qa-custom-messages-layer.php
@@ -94,4 +94,16 @@ class qa_html_theme_layer extends qa_html_theme_base {
         }
       }
   }
+  
+  public function form_buttons($form, $columns)
+  {
+      if (qa_opt('site_theme') === CML_TARGET_THEME_NAME && $this->template === 'message') {
+          if(isset($form['buttons']['send'])) {
+              $tags = $form['buttons']['send']['tags'];
+              $tags .= " id='send-message'";
+              $form['buttons']['send']['tags'] = $tags;
+          }
+      }
+      qa_html_theme_base::form_buttons($form, $columns);
+  }
 }


### PR DESCRIPTION
* 未入力時は「送信」ボタンを使用できないようにする
  - スペースや改行のみの場合は未入力とする

* 送信ボタンを押したあとの未入力チェックは q2a-message-editor で行っています
