### PR TITLE
1525 メッセージ画面での通知ボックスのレイアウト崩れ

### DIFF
--- a/css/messages.css
+++ b/css/messages.css
@@ -12,7 +12,10 @@
   width: auto;
   overflow: auto;
 }
-.mdl-list__item {
+.qa-template-messages main .mdl-list__item,
+.qa-template-messages-select-user main .mdl-list__item,
+.qa-template-messages-select-group main .mdl-list__item,
+.qa-template-messages-select-add-user main .mdl-list__item {
   border-top: 1px solid #ccc;
   padding: 0;
 }


### PR DESCRIPTION
- メッセージボックスのリスト部分のcss修正
  - メッセージボックス内のリストにのみ適用するように