### PR TITLE
1655 飼育日誌に添付したA4サイズの画像が押しつぶされる

### DIFF
--- a/css/messages.css
+++ b/css/messages.css
@@ -128,6 +128,9 @@ flex-direction: column;
 .message-container .avatar {
 margin: 16px;
 }
+.message-container .message {
+  width: 100%;
+}
 .message-container .message .ballon {
 border-radius: 8px;
 font-size: 16px;


### PR DESCRIPTION
- メッセージ内画像がはみ出さないように（IE）