### PR TITLE
1772 プライベートメッセージが送れない状況でも上部のinformationが表示される

### DIFF
--- a/qa-custom-messages-layer.php
+++ b/qa-custom-messages-layer.php
@@ -64,6 +64,14 @@ class qa_html_theme_layer extends qa_html_theme_base {
         } elseif ($this->template === 'messages-select-add-user') {
           $this->output_select_add_user_button();
         }
+    } elseif ($region === 'main' && $place === 'high') {
+        if ($this->template === 'message') {
+            $show_ok = cml_db_client::check_show_user_message(qa_get_logged_in_userid(), 30);
+            $messages = isset($content['message_list']);
+            if ($messages || $show_ok) {
+                $this->output(@$this->content['no_post_html']);
+            }
+        }
     }
     qa_html_theme_base::widgets($region, $place);
   }

--- a/qa-custom-messages-layer.php
+++ b/qa-custom-messages-layer.php
@@ -67,7 +67,7 @@ class qa_html_theme_layer extends qa_html_theme_base {
     } elseif ($region === 'main' && $place === 'high') {
         if ($this->template === 'message') {
             $show_ok = cml_db_client::check_show_user_message(qa_get_logged_in_userid(), 30);
-            $messages = isset($content['message_list']);
+            $messages = isset($this->content['message_list']);
             if ($messages || $show_ok) {
                 $this->output(@$this->content['no_post_html']);
             }


### PR DESCRIPTION
- メッセージ未投稿の場合の案内をこのプラグインで出力
- メッセージリストの表示条件と同じにする
  - ３０日以内に質問や回答、日誌を投稿している場合
